### PR TITLE
Fix timezones

### DIFF
--- a/client_src/src/app/components/Holidays/HolidayRow.tsx
+++ b/client_src/src/app/components/Holidays/HolidayRow.tsx
@@ -69,7 +69,8 @@ class HolidayRow extends React.Component<WithStyles<typeof styles> & IProps> {
   }
 
   handleChangeHolidayDate = event => {
-    this.props.changeHolidayDate({index: this.props.index, date: event})
+    let isoString = event.toISOString().split("T")[0]
+    this.props.changeHolidayDate({index: this.props.index, date: isoString})
   }
 
   handleDelete = event => {
@@ -81,9 +82,12 @@ class HolidayRow extends React.Component<WithStyles<typeof styles> & IProps> {
 
   render() {
     const { classes, date } = this.props;
-  
+    let yearMonthDay = null
+    if(date){
+      yearMonthDay = date
+    }
     let holidayDate = <DatePicker
-      selected={date}
+      selected={yearMonthDay}
       placeholderText="mm / dd / yyyy"
       onChange={this.handleChangeHolidayDate}
       className={classes.dateInput}

--- a/client_src/src/app/components/Schedules/SingleDateTimeRange.tsx
+++ b/client_src/src/app/components/Schedules/SingleDateTimeRange.tsx
@@ -17,7 +17,7 @@ import { deleteSingleDateTimeRange, changeDateOfSingleDateTimeRange, changeStart
 
 var moment = require('moment-timezone');
 
-const format = 'h:mm a';
+const TimeFormat = 'h:mm a';
 
 const styles = theme => createStyles({
   root: {
@@ -89,18 +89,18 @@ class SingleDateTimeRange extends React.Component<WithStyles<typeof styles> & IP
 
   handleStartTimeChange = (value) => {
     const { changeStartOfSingleDateTimeRange, index } = this.props
-    changeStartOfSingleDateTimeRange({index, value: value.format(format) })
+    changeStartOfSingleDateTimeRange({index, value: value.format(TimeFormat) })
   }
 
   handleEndTimeChange = (value) => {
     const { changeEndOfSingleDateTimeRange, index } = this.props
-    changeEndOfSingleDateTimeRange({index, value: value.format(format) })
+    changeEndOfSingleDateTimeRange({index, value: value.format(TimeFormat) })
   }
 
   handleDateChange = (value) =>  {
     const { changeDateOfSingleDateTimeRange, index } = this.props
-    console.log("date single date time range", value)
-    changeDateOfSingleDateTimeRange({ index, date: value})
+    let isoString = value.toISOString().split("T")[0]
+    changeDateOfSingleDateTimeRange({ index, date: isoString})
   };
 
   handleCheckboxChange = (event) => {
@@ -115,22 +115,25 @@ class SingleDateTimeRange extends React.Component<WithStyles<typeof styles> & IP
   }
 
   render() {
-    const { classes, closed_all_day } = this.props
-
+    const { classes, closed_all_day, date } = this.props
+    let yearMonthDay = null
+    if(date){
+      yearMonthDay = date
+    }
     let dateComponent = <DatePicker
       className={classes.dateInput}
-      selected={this.props.date}
+      selected={yearMonthDay}
       placeholderText="mm / dd / yyyy"
       onChange={this.handleDateChange}
       calendarClassName={classes.calendar}
     />
 
-    let startValue = moment(this.props.start, format)
+    let startValue = moment(this.props.start, TimeFormat)
     if(!startValue.isValid()) {
       startValue = null
     }
 
-    let endValue = moment(this.props.end, format)
+    let endValue = moment(this.props.end, TimeFormat)
     if(!endValue.isValid()) {
       endValue = null
     }
@@ -149,7 +152,7 @@ class SingleDateTimeRange extends React.Component<WithStyles<typeof styles> & IP
                 <TimePicker
                   showSecond={false}
                   onChange={this.handleStartTimeChange}
-                  format={format}
+                  format={TimeFormat}
                   use12Hours
                   placeholder={"00:00"}
                   value={startValue}
@@ -165,7 +168,7 @@ class SingleDateTimeRange extends React.Component<WithStyles<typeof styles> & IP
                 <TimePicker
                   showSecond={false}
                   onChange={this.handleEndTimeChange}
-                  format={format}
+                  format={TimeFormat}
                   use12Hours
                   placeholder={"00:00"}
                   value={endValue}

--- a/common/models/holiday-list.js
+++ b/common/models/holiday-list.js
@@ -171,7 +171,9 @@ function createHolidays(holidayListDB, holidays) {
   logger.info('Creating holidays', holidayListDB, holidays)
   let createPromises = []
   for(var i = 0; i < holidays.length; i++) {
-    createPromises.push(createHoliday(holidayListDB, holidays[i]))
+    if(holidays[i].date){
+      createPromises.push(createHoliday(holidayListDB, holidays[i]))
+    }
   }
   return Promise.all(createPromises)
 }

--- a/common/models/holiday.js
+++ b/common/models/holiday.js
@@ -4,7 +4,6 @@ var logger = require('../../server/logger')
 
 module.exports = function(Holiday) {
   Holiday.validatesUniquenessOf('name', {message: 'Name already exists'})
-  //TODO: Should this.date be converted to just a date or PST?
   Holiday.prototype.isToday = function() {
     console.log('Checking if holiday is today', this.date)
     logger.info('Checking if holiday is today', this.date)

--- a/common/models/holiday.js
+++ b/common/models/holiday.js
@@ -4,7 +4,7 @@ var logger = require('../../server/logger')
 
 module.exports = function(Holiday) {
   Holiday.validatesUniquenessOf('name', {message: 'Name already exists'})
-
+  //TODO: Should this.date be converted to just a date or PST?
   Holiday.prototype.isToday = function() {
     console.log('Checking if holiday is today', this.date)
     logger.info('Checking if holiday is today', this.date)

--- a/common/models/schedule.js
+++ b/common/models/schedule.js
@@ -233,7 +233,9 @@ function createSingleDateTimeRanges(createdSchedule, singleDateTimeRanges) {
   console.log('Creating single date time ranges', createdSchedule, singleDateTimeRanges)
   let createPromises = []
   for(var i = 0; i < singleDateTimeRanges.length; i++) {
-    createPromises.push(createSingleDateTimeRange(createdSchedule, singleDateTimeRanges[i]))
+    if((singleDateTimeRanges[i].start && singleDateTimeRanges[i].end) || singleDateTimeRanges[i].closed_all_day) {
+      createPromises.push(createSingleDateTimeRange(createdSchedule, singleDateTimeRanges[i]))
+    }
   }
   return Promise.all(createPromises)
 }


### PR DESCRIPTION
- DatePicker uses Date js. When selecting a date it outputs a date object in MST time on my laptop. Using toISODate() to convert the object to ISO, it would give me  6am UTC. EX: 2019-09-17T06:00:00.000Z
- When a date is selected, strip out the timezone data and save only the date. 
- Ex: ISO string to a date string (ex: “2019-09-17T22:03:20.954Z” --> “2019-09-17")
- Moment js, will use the date saved in the DB and compare it to the day in PST timezone.

** Its possible that someone will set a date from Asia or something which may cause the conversion from new Date() to ISO...to be the incorrect date. During my testing, I could not confirm this outcome because my computer was always converting to 06:00:00Z, even which switching to other timezones through my computer clock.

Notes:
I have the special schedule fix up in Lab to test. I changed the format of the dates that is saved to the database from a ISO string to a date string (ex: “2019-09-17T22:03:20.954Z” --> “2019-09-17"). I also had to go through all the date columns in the “Special Schedules” and “Holidays” tables. I updated the old entries to the new format. If DCSS asks why these changes need to be done, its because we’ve improved on handling timezone syncing to PST time.